### PR TITLE
Cleanup message

### DIFF
--- a/lib/middleman-favicon-maker/extension.rb
+++ b/lib/middleman-favicon-maker/extension.rb
@@ -38,7 +38,7 @@ module Middleman
 
         template_files.uniq.each do |template_filepath|
           template_filepath.gsub!(options[:template_dir], options[:output_dir])
-          File.exists?(template_filepath) and builder.remove_file(template_filepath)
+          builder.remove_file(template_filepath) if File.exists?(template_filepath)
         end
 
       end


### PR DESCRIPTION
`remove _favicon_template.png` was being shown when the file is actually not there to begin with

Side note about command line messages: Currently we see all the images are removed and re-generated, is it possible to avoid remaking the images every time and instead just show they are `identical` like most other files are?
It would remove some lines of the build message and save some build time, but of course it's not necessary.
