### PR TITLE
Add icon resources on manipulate_resource_list

### DIFF
--- a/lib/middleman-favicon-maker/extension.rb
+++ b/lib/middleman-favicon-maker/extension.rb
@@ -45,6 +45,19 @@ module Middleman
 
       end
 
+      def manipulate_resource_list(resources)
+        options[:icons].each do|src, items|
+          resources += items.map do|item|
+            ::Middleman::Sitemap::Resource.new(
+              app.sitemap,
+              item[:icon],
+              File.join(options[:template_dir], src)
+            )
+          end
+        end
+        resources
+      end
+
       private
 
       def source_path


### PR DESCRIPTION
Hi,

I'm using both [middleman-favicon-maker] and [middleman-s3_sync].

[middleman-s3_sync] relies sitemap resources to retrieve assets to sync with Amazon S3 but assets built with [middleman-favicon-maker] are not included in the sitemap.

So I added `manipulate_resource_list` hook to append built assets with this change.

Thanks.

[middleman-s3_sync]: https://github.com/fredjean/middleman-s3_sync
[middleman-favicon-maker]: https://github.com/follmann/middleman-favicon-maker