### PR TITLE
Fix source file path for the sitemap - this PR fix #44

### DIFF
--- a/lib/middleman-favicon-maker/extension.rb
+++ b/lib/middleman-favicon-maker/extension.rb
@@ -51,7 +51,7 @@ module Middleman
             ::Middleman::Sitemap::Resource.new(
               app.sitemap,
               item[:icon],
-              File.join(options[:template_dir], src)
+              File.join(app.root, options[:template_dir], src)
             )
           end
         end


### PR DESCRIPTION
The source file path was incorrect. This PR fix #44.

@follmann Please publish a new version (`4.0.5`) of `middleman-favicon-maker`. 🎉 