### PR TITLE
Fixing favicon source duplicating app path

### DIFF
--- a/lib/middleman-favicon-maker/extension.rb
+++ b/lib/middleman-favicon-maker/extension.rb
@@ -61,11 +61,11 @@ module Middleman
       private
 
       def source_path
-        File.join(app.root, app.config.source)
+        File.join(app.config.source)
       end
 
       def build_path
-        File.join(app.root, app.config.build_dir)
+        File.join(app.config.build_dir)
       end
     end
   end


### PR DESCRIPTION
Fixes issue #46 

I ran into the same problem described in #46, removing the `app.root` fixed it.